### PR TITLE
Fix dependencies

### DIFF
--- a/.github/workflows/quality_checks.yml
+++ b/.github/workflows/quality_checks.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "omnisolver ~= 0.0.3",
-    "numba ~= 0.56.4",
-    "pluggy ~= 0.13.1",
-    "numpy ~= 1.19.4"
+    "numba ~= 0.57",
+    "pluggy ~= 0.13",
+    "numpy ~= 1.19"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This fixes dependencies by:
- bumping version of numba
- loosening version of numpy
- loosening versions of some other dependencies (not relevant to the problem pointed out by the reviewer)
Thanks to the above changes, we got rid of the installation problems + omnisolver-pt is also compatible with Python 3.11.