### PR TITLE
Update .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+
 python:
-  version: "3.8"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
This updates .readthedocs.yml file in accordance to the recently issued [deprecation notice](https://blog.readthedocs.com/use-build-os-config/).