### PR TITLE
Add tracking of more than one low-energy state

### DIFF
--- a/.github/workflows/quality_checks.yml
+++ b/.github/workflows/quality_checks.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,10 @@ repos:
     rev: v1.5.1
     hooks:
       - id: mypy
+        args: [
+          --namespace-packages,
+          --explicit-package-bases,
+          --ignore-missing-imports,
+          --install-types,
+          --non-interactive
+        ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,24 +5,24 @@ default_stages: [commit, push]
 
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files", "--check"]
 
   - repo: https://github.com/ambv/black
-    rev: 21.6b0
+    rev: 23.9.1
     hooks:
       - id: black
         args: ["--check"]
         language_version: python3.9
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.0
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
     hooks:
       - id: flake8
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v1.5.1
     hooks:
       - id: mypy

--- a/omnisolver/pt/_numba_helpers.py
+++ b/omnisolver/pt/_numba_helpers.py
@@ -1,0 +1,11 @@
+import os
+
+from numba import typeof
+
+
+def numba_type_of_instance(t):
+    return t if os.getenv("NUMBA_DISABLE_JIT", "0") == "1" else typeof(t).class_type.instance_type
+
+
+def numba_type_of_cls(t):
+    return t if os.getenv("NUMBA_DISABLE_JIT", "0") == "1" else t.class_type.instance_type

--- a/omnisolver/pt/_numba_helpers.py
+++ b/omnisolver/pt/_numba_helpers.py
@@ -1,11 +1,20 @@
+"""Some helpers easing the pain of interacting with numba."""
 import os
 
 from numba import typeof
 
 
 def numba_type_of_instance(t):
+    """Get numba type of a jitted class instance.
+
+    This works both in normal and debug mode.
+    """
     return t if os.getenv("NUMBA_DISABLE_JIT", "0") == "1" else typeof(t).class_type.instance_type
 
 
 def numba_type_of_cls(t):
+    """Get numba type of a jitted class.
+
+    This works both in normal and debug mode.
+    """
     return t if os.getenv("NUMBA_DISABLE_JIT", "0") == "1" else t.class_type.instance_type

--- a/omnisolver/pt/model.py
+++ b/omnisolver/pt/model.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from typing import Type
 
 import numba
 import numpy as np
@@ -37,7 +38,7 @@ class IsingModel:
 
 
 @lru_cache
-def _create_ising_model(spec):
+def _create_ising_model(spec) -> Type[IsingModel]:
     return numba.experimental.jitclass(spec)(IsingModel)
 
 

--- a/omnisolver/pt/pt.yml
+++ b/omnisolver/pt/pt.yml
@@ -25,3 +25,6 @@ sample_args:
     help: "inverse temperature of the coldest replica"
     type: float
     default: 1.0
+  - name: "num_states"
+    help: "number of lowest energy states to keep track of."
+    default: 1

--- a/omnisolver/pt/replica.py
+++ b/omnisolver/pt/replica.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ._numba_helpers import numba_type_of_instance
 from .model import IsingModel
-from .tracking import Tracker, tracker_factory
+from .tracking import Tracker, construct_tracker
 
 
 class Replica:
@@ -102,7 +102,7 @@ def initialize_replica(model: IsingModel, initial_state, beta, num_states) -> Re
     scalar_dtype = numba.typeof(model.h_vec).dtype
     state_dtype = numba.types.int8[:]
 
-    tracker = tracker_factory(scalar_dtype, num_states)
+    tracker = construct_tracker(scalar_dtype, num_states)
 
     spec = (
         ("model", numba_type_of_instance(model)),

--- a/omnisolver/pt/replica.py
+++ b/omnisolver/pt/replica.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 import numba
 import numpy as np
 
+from ._numba_helpers import numba_type_of_instance
 from .model import IsingModel
 from .tracking import tracker_factory
 
@@ -108,7 +109,7 @@ def initialize_replica(model: IsingModel, initial_state, beta, num_states) -> Re
         ("current_energy", scalar_dtype),
         ("best_state_so_far", state_dtype),
         ("best_energy_so_far", scalar_dtype),
-        ("tracker", numba.typeof(tracker).class_type.instance_type),
+        ("tracker", numba_type_of_instance(tracker)),
     )
 
     replica_cls = _create_replica_cls(spec)

--- a/omnisolver/pt/replica.py
+++ b/omnisolver/pt/replica.py
@@ -67,7 +67,7 @@ class Replica:
             if self.should_accept_flip(energy_diff):
                 self.current_energy -= energy_diff
                 self.current_state[i] = -self.current_state[i]
-                self.tracker.store(self.current_state, self.current_energy)
+                self.tracker.digest(self.current_state, self.current_energy)
 
 
 @lru_cache

--- a/omnisolver/pt/replica.py
+++ b/omnisolver/pt/replica.py
@@ -7,7 +7,7 @@ import numpy as np
 from .model import IsingModel
 
 
-class Replica:
+class BaseReplica:
     """Replica of Ising spin-glass used in parallel tempering algorithm.
 
     :ivar model: Instance of Ising model this replica uses.
@@ -37,9 +37,6 @@ class Replica:
         self.current_state = initial_state.copy()
         self.current_energy = model.energy(initial_state)
 
-        self.best_state_so_far = self.current_state.copy()
-        self.best_energy_so_far = self.current_energy
-
     def should_accept_flip(self, energy_diff: float) -> bool:
         """Determine if this replica should accept spin flip resulting in given energy difference.
 
@@ -66,9 +63,25 @@ class Replica:
             if self.should_accept_flip(energy_diff):
                 self.current_energy -= energy_diff
                 self.current_state[i] = -self.current_state[i]
-                if self.current_energy < self.best_energy_so_far:
-                    self.best_energy_so_far = self.current_energy
-                    self.best_state_so_far = self.current_state.copy()
+                self.update_tracking_info()
+
+    def update_tracking_info(self):
+        pass
+
+
+class Replica(BaseReplica):
+    __init__base = BaseReplica.__init__
+
+    def __init__(self, model: IsingModel, initial_state, beta):
+        self.__init__base(model, initial_state, beta)
+
+        self.best_state_so_far = self.current_state.copy()
+        self.best_energy_so_far = self.current_energy
+
+    def update_tracking_info(self):
+        if self.current_energy < self.best_energy_so_far:
+            self.best_energy_so_far = self.current_energy
+            self.best_state_so_far = self.current_state.copy()
 
 
 @lru_cache

--- a/omnisolver/pt/replica.py
+++ b/omnisolver/pt/replica.py
@@ -40,6 +40,7 @@ class Replica:
         self.current_state = initial_state.copy()
         self.current_energy = model.energy(initial_state)
         self.tracker = tracker
+        self.tracker.digest(self.current_state, self.current_energy)
 
     def should_accept_flip(self, energy_diff: float) -> bool:
         """Determine if this replica should accept spin flip resulting in given energy difference.
@@ -101,7 +102,7 @@ def initialize_replica(model: IsingModel, initial_state, beta, num_states) -> Re
     scalar_dtype = numba.typeof(model.h_vec).dtype
     state_dtype = numba.types.int8[:]
 
-    tracker = tracker_factory(scalar_dtype, num_states)(initial_state, model.energy(initial_state))
+    tracker = tracker_factory(scalar_dtype, num_states)
 
     spec = (
         ("model", numba_type_of_instance(model)),

--- a/omnisolver/pt/tracking.py
+++ b/omnisolver/pt/tracking.py
@@ -6,6 +6,8 @@ import numpy as np
 from numba.experimental import jitclass
 from numba.types import List, int8, int64
 
+from ._numba_helpers import numba_type_of_cls
+
 
 class Tracker(Protocol):
     def records(self) -> Tuple[Sequence[np.ndarray], Sequence[float]]:
@@ -42,7 +44,7 @@ def _low_energy_spectrum_tracker(energy_dtype):
         def __lt__(self, other):
             return self.energy < other.energy
 
-    @jitclass((("heap", List(_HeapItem.class_type.instance_type)), ("num_states", int64)))
+    @jitclass((("heap", List(numba_type_of_cls(_HeapItem))), ("num_states", int64)))
     class _LowEnergySpectrumTracker:
         def __init__(self, initial_state, initial_energy, num_states):
             self.heap = [_HeapItem(initial_state.copy(), -initial_energy)]

--- a/omnisolver/pt/tracking.py
+++ b/omnisolver/pt/tracking.py
@@ -5,7 +5,7 @@ from numba.experimental import jitclass
 from numba.types import int8
 
 
-class GroundOnlyTracker:
+class _GroundOnlyTracker:
     def __init__(self, initial_state, initial_energy):
         self.best_state_so_far = initial_state.copy()
         self.best_energy_so_far = initial_energy
@@ -16,13 +16,13 @@ class GroundOnlyTracker:
     def store(self, new_state, new_energy):
         if new_energy < self.best_energy_so_far:
             self.best_energy_so_far = new_energy
-            self.best_state_so_far = new_state
+            self.best_state_so_far = new_state.copy()
 
 
 @lru_cache
-def construct_tracker(energy_dtype, max_num_states) -> Type[GroundOnlyTracker]:
+def tracker_factory(energy_dtype, max_num_states) -> Type[_GroundOnlyTracker]:
     if max_num_states == 1:
         return jitclass((("best_state_so_far", int8[:]), ("best_energy_so_far", energy_dtype)))(
-            GroundOnlyTracker
+            _GroundOnlyTracker
         )
     raise NotImplementedError("Only single state tracking is implemented so far.")

--- a/omnisolver/pt/tracking.py
+++ b/omnisolver/pt/tracking.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from heapq import heappop, heappush
 from typing import Protocol, Sequence, Tuple
 
 import numpy as np
@@ -51,6 +52,20 @@ def _low_energy_spectrum_tracker(energy_dtype):
             energies = [item.energy for item in self.heap]
             states = [item.state for item in self.heap]
             return states, energies
+
+        def store(self, new_state, new_energy):
+            if self._is_already_stored(new_state):
+                return
+            new_item = _HeapItem(new_state, new_energy)
+            heappush(self.heap, new_item)
+            if len(self.heap) > self.num_states:
+                heappop(self.heap)
+
+        def _is_already_stored(self, state):
+            for item in self.heap:
+                if np.array_equal(state, item.state):
+                    return True
+            return False
 
     return _LowEnergySpectrumTracker
 

--- a/omnisolver/pt/tracking.py
+++ b/omnisolver/pt/tracking.py
@@ -1,0 +1,28 @@
+from functools import lru_cache
+from typing import Type
+
+from numba.experimental import jitclass
+from numba.types import int8
+
+
+class GroundOnlyTracker:
+    def __init__(self, initial_state, initial_energy):
+        self.best_state_so_far = initial_state.copy()
+        self.best_energy_so_far = initial_energy
+
+    def records(self):
+        return [self.best_state_so_far], [self.best_energy_so_far]
+
+    def store(self, new_state, new_energy):
+        if new_energy < self.best_energy_so_far:
+            self.best_energy_so_far = new_energy
+            self.best_state_so_far = new_state
+
+
+@lru_cache
+def construct_tracker(energy_dtype, max_num_states) -> Type[GroundOnlyTracker]:
+    if max_num_states == 1:
+        return jitclass((("best_state_so_far", int8[:]), ("best_energy_so_far", energy_dtype)))(
+            GroundOnlyTracker
+        )
+    raise NotImplementedError("Only single state tracking is implemented so far.")

--- a/omnisolver/pt/tracking.py
+++ b/omnisolver/pt/tracking.py
@@ -8,9 +8,14 @@ from numba.types import List, int8, int64
 
 from ._numba_helpers import numba_type_of_cls
 
+Records = Tuple[Sequence[np.ndarray], Sequence[float]]
+
 
 class Tracker(Protocol):
-    def records(self) -> Tuple[Sequence[np.ndarray], Sequence[float]]:  # pragma: no cover
+    def records(self) -> Records:  # pragma: no cover
+        raise NotImplementedError()
+
+    def store(self, new_state: np.ndarray, new_energy: float):  # pragma: no cover
         raise NotImplementedError()
 
 
@@ -26,7 +31,7 @@ class _GroundOnlyTracker:
         self.best_state_so_far = initial_state.copy()
         self.best_energy_so_far = initial_energy
 
-    def records(self):
+    def records(self) -> Records:
         return [self.best_state_so_far], [self.best_energy_so_far]
 
     def store(self, new_state, new_energy):

--- a/omnisolver/pt/tracking.py
+++ b/omnisolver/pt/tracking.py
@@ -194,7 +194,7 @@ def _ground_only_tracker_cls(energy_dtype):
     )(_GroundOnlyTracker)
 
 
-def tracker_factory(energy_dtype, num_states) -> Tracker:
+def construct_tracker(energy_dtype, num_states) -> Tracker:
     """Construct a tracker factory for a given dtype and number of states.
 
     :param energy_dtype: the data type of energies to be stored by the tracker.

--- a/omnisolver/pt/tracking.py
+++ b/omnisolver/pt/tracking.py
@@ -14,7 +14,7 @@ However, we distinguish it from the second one as it has significantly more perf
 specialized implementation.
 
 To keep the user away from having to manually construct trackers, this module provides a
-simple function `tracker factory(dtype, num_states)`, which constructs an appropriate
+simple function `construct_tracker(dtype, num_states)`, which constructs an appropriate
 tracker given the dtype of the model and desired number of states to store.
 """
 from functools import lru_cache
@@ -195,12 +195,12 @@ def _ground_only_tracker_cls(energy_dtype):
 
 
 def construct_tracker(energy_dtype, num_states) -> Tracker:
-    """Construct a tracker factory for a given dtype and number of states.
+    """Construct a tracker for a given dtype and number of states.
 
     :param energy_dtype: the data type of energies to be stored by the tracker.
     :param num_states: number of states that should be stored by the tracker.
-    :return: an appropriate tracker factory, either one that constructs the
-     _GroundOnlyTracker or _LowEnergySpectrumTracker.
+    :return: an appropriate tracker, an instance of (jitted) either _GroundOnlyTracker or
+    _LowEnergySpectrumTracker.
     """
     if num_states == 1:
         return _ground_only_tracker_cls(energy_dtype)()

--- a/omnisolver/pt/tracking.py
+++ b/omnisolver/pt/tracking.py
@@ -12,6 +12,9 @@ Records = Tuple[Sequence[np.ndarray], Sequence[float]]
 
 
 class Tracker(Protocol):
+    def __init__(self, initial_state: np.ndarray, initial_energy: float):  # pragma: no cover
+        raise NotImplementedError()
+
     def records(self) -> Records:  # pragma: no cover
         raise NotImplementedError()
 
@@ -34,7 +37,7 @@ class _GroundOnlyTracker:
     def records(self) -> Records:
         return [self.best_state_so_far], [self.best_energy_so_far]
 
-    def store(self, new_state, new_energy):
+    def store(self, new_state, new_energy) -> None:
         if new_energy < self.best_energy_so_far:
             self.best_energy_so_far = new_energy
             self.best_state_so_far = new_state.copy()
@@ -48,7 +51,7 @@ def _low_energy_spectrum_tracker(energy_dtype):
             self.state = state
             self.energy = energy
 
-        def __lt__(self, other):
+        def __lt__(self, other) -> bool:
             return self.energy < other.energy
 
     @jitclass((("heap", List(numba_type_of_cls(_HeapItem))), ("num_states", int64)))

--- a/omnisolver/pt/tracking.py
+++ b/omnisolver/pt/tracking.py
@@ -1,8 +1,19 @@
 from functools import lru_cache
-from typing import Type
+from typing import Protocol, Sequence, Tuple
 
+import numpy as np
 from numba.experimental import jitclass
-from numba.types import int8
+from numba.types import List, int8, int64
+
+
+class Tracker(Protocol):
+    def records(self) -> Tuple[Sequence[np.ndarray], Sequence[float]]:
+        raise NotImplementedError()
+
+
+class TrackerFactory(Protocol):
+    def __call__(self, initial_state: np.ndarray, initial_energy: np.ndarray) -> Tracker:
+        raise NotImplementedError()
 
 
 class _GroundOnlyTracker:
@@ -20,9 +31,41 @@ class _GroundOnlyTracker:
 
 
 @lru_cache
-def tracker_factory(energy_dtype, max_num_states) -> Type[_GroundOnlyTracker]:
-    if max_num_states == 1:
+def _low_energy_spectrum_tracker(energy_dtype):
+    @jitclass((("state", int8[:]), ("energy", energy_dtype)))
+    class _HeapItem:
+        def __init__(self, state, energy):
+            self.state = state
+            self.energy = energy
+
+        def __lt__(self, other):
+            return self.energy < other.energy
+
+    @jitclass((("heap", List(_HeapItem.class_type.instance_type)), ("num_states", int64)))
+    class _LowEnergySpectrumTracker:
+        def __init__(self, initial_state, initial_energy, num_states):
+            self.heap = [_HeapItem(initial_state.copy(), initial_energy)]
+            self.num_states = num_states
+
+        def records(self) -> Tuple[Sequence[np.ndarray], Sequence[float]]:
+            energies = [item.energy for item in self.heap]
+            states = [item.state for item in self.heap]
+            return states, energies
+
+    return _LowEnergySpectrumTracker
+
+
+@lru_cache
+def tracker_factory(energy_dtype, num_states) -> TrackerFactory:
+    if num_states == 1:
         return jitclass((("best_state_so_far", int8[:]), ("best_energy_so_far", energy_dtype)))(
             _GroundOnlyTracker
         )
-    raise NotImplementedError("Only single state tracking is implemented so far.")
+    else:
+
+        def _tracker_factory(initial_state: np.ndarray, initial_energy: float) -> Tracker:
+            return _low_energy_spectrum_tracker(energy_dtype)(
+                initial_state, initial_energy, num_states
+            )
+
+        return _tracker_factory

--- a/omnisolver/pt/tracking.py
+++ b/omnisolver/pt/tracking.py
@@ -10,12 +10,14 @@ from ._numba_helpers import numba_type_of_cls
 
 
 class Tracker(Protocol):
-    def records(self) -> Tuple[Sequence[np.ndarray], Sequence[float]]:
+    def records(self) -> Tuple[Sequence[np.ndarray], Sequence[float]]:  # pragma: no cover
         raise NotImplementedError()
 
 
 class TrackerFactory(Protocol):
-    def __call__(self, initial_state: np.ndarray, initial_energy: np.ndarray) -> Tracker:
+    def __call__(
+        self, initial_state: np.ndarray, initial_energy: np.ndarray
+    ) -> Tracker:  # pragma: no cover
         raise NotImplementedError()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.8"
 dependencies = [
     "omnisolver ~= 0.0.3",
     "numba >= 0.56.4",
-    "pluggy ~= 0.13.1",
+    "pluggy ~= 0.13",
     "numpy >= 1.19.4"
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "omnisolver ~= 0.0.3",
-    "numba ~= 0.56.4",
+    "numba >= 0.56.4",
     "pluggy ~= 0.13.1",
-    "numpy ~= 1.19.4"
+    "numpy >= 1.19.4"
 ]
 dynamic = ["version"]
 

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -19,7 +19,10 @@ class TestPerformingMonteCarloSweeps:
         initial_state = np.ones(3, dtype=np.int8)
 
         replicas = numba.typed.List(
-            [initialize_replica(model, initial_state, beta) for beta in np.linspace(0.1, 1.0, 10)]
+            [
+                initialize_replica(model, initial_state, beta, 1)
+                for beta in np.linspace(0.1, 1.0, 10)
+            ]
         )
 
         perform_monte_carlo_sweeps(replicas, 1)
@@ -33,8 +36,10 @@ class TestReplicaExchangeCriterion:
     ):
         numba_seed(42)
         model = ising_model(np.ones(3), np.zeros((3, 3)))
-        replica_1 = initialize_replica(model, np.ones(3, dtype=np.int8), beta=0.1)
-        replica_2 = initialize_replica(model, np.array([-1, 1, -1], dtype=np.int8), beta=0.01)
+        replica_1 = initialize_replica(model, np.ones(3, dtype=np.int8), beta=0.1, num_states=1)
+        replica_2 = initialize_replica(
+            model, np.array([-1, 1, -1], dtype=np.int8), beta=0.01, num_states=1
+        )
 
         assert should_exchange_states(replica_1, replica_2)
         assert should_exchange_states(replica_2, replica_1)
@@ -53,8 +58,8 @@ class TestReplicaExchangeCriterion:
         beta_2 = beta_1 - (threshold_beta_difference - 0.1)
         numba_seed(42)
 
-        replica_1 = initialize_replica(model, initial_state_1, beta_1)
-        replica_2 = initialize_replica(model, initial_state_2, beta_2)
+        replica_1 = initialize_replica(model, initial_state_1, beta_1, 1)
+        replica_2 = initialize_replica(model, initial_state_2, beta_2, 1)
 
         assert should_exchange_states(replica_1, replica_2)
 
@@ -71,8 +76,8 @@ class TestReplicaExchangeCriterion:
         beta_2 = beta_1 - (threshold_beta_difference + 0.1)
         numba_seed(42)
 
-        replica_1 = initialize_replica(model, initial_state_1, beta_1)
-        replica_2 = initialize_replica(model, initial_state_2, beta_2)
+        replica_1 = initialize_replica(model, initial_state_1, beta_1, 1)
+        replica_2 = initialize_replica(model, initial_state_2, beta_2, 1)
 
         assert not should_exchange_states(replica_1, replica_2)
 
@@ -86,8 +91,8 @@ class TestReplicaExchange:
         initial_state_2 = np.ones(3, dtype=np.int8)
         energy_1 = model.energy(initial_state_1)
         energy_2 = model.energy(initial_state_2)
-        replica_1 = initialize_replica(model, initial_state_1, beta=0.01)
-        replica_2 = initialize_replica(model, initial_state_1, beta=0.1)
+        replica_1 = initialize_replica(model, initial_state_1, beta=0.01, num_states=1)
+        replica_2 = initialize_replica(model, initial_state_1, beta=0.1, num_states=1)
 
         exchange_states(replica_1, replica_2)
 
@@ -103,8 +108,8 @@ class TestReplicaExchange:
         model = ising_model(h_vec, j_mat)
         initial_state = np.ones(3, dtype=np.int8)
 
-        replica_1 = initialize_replica(model, initial_state, beta=0.01)
-        replica_2 = initialize_replica(model, initial_state, beta=0.1)
+        replica_1 = initialize_replica(model, initial_state, beta=0.01, num_states=1)
+        replica_2 = initialize_replica(model, initial_state, beta=0.1, num_states=1)
 
         exchange_states(replica_1, replica_2)
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,11 +1,12 @@
 """Test cases for PTSampler."""
 import dimod
+from dimod import generators
 
 from omnisolver.pt.sampler import PTSampler
 
 
 class TestSamplingIsingModel:
-    def test_resulting_state_and_energy_agree(self):
+    def test_lowest_resulting_state_and_its_energy_agree(self):
         biases = {0: 0.5, 1: -2.0, 2: 3.0}
         couplings = {(0, 1): -1, (2, 1): -3}
         sampler = PTSampler()
@@ -22,6 +23,25 @@ class TestSamplingIsingModel:
 
         bqm = dimod.BQM.from_ising(biases, couplings)
         assert bqm.energy(result.first.sample) == result.first.energy
+
+    def test_number_of_states_and_their_energies_are_correct(self):
+        bqm = generators.randint(100, "BINARY", seed=1234)
+
+        sampler = PTSampler()
+
+        result = sampler.sample(
+            bqm,
+            num_replicas=3,
+            num_pt_steps=100,
+            num_sweeps=10,
+            beta_min=0.01,
+            beta_max=0.1,
+            num_states=100,
+        )
+
+        assert len(result.samples()) == 100
+
+        assert all(bqm.energy(row["sample"]) == row["energy"] for row in result.record)
 
 
 class TestPTSamplerProperties:

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -32,7 +32,7 @@ class TestSamplingIsingModel:
         result = sampler.sample(
             bqm,
             num_replicas=3,
-            num_pt_steps=100,
+            num_pt_steps=10,
             num_sweeps=10,
             beta_min=0.01,
             beta_max=0.1,

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -12,56 +12,56 @@ def assert_records_agree(tracker, states, energies):
     np.testing.assert_array_equal(recorded_energies, energies)
 
 
-@pytest.mark.parametrize(
-    "tracker_cls",
-    [
-        tracker_factory(float32, 1),
-        tracker_factory(float64, 1),
-        tracker_factory(float32, 100),
-        tracker_factory(float64, 100),
-    ],
-)
 class TestTrackersInitialization:
-    def test_new_ground_only_tracker_retains_initial_configuration_as_the_best_one(
-        self, tracker_cls
-    ):
+    @pytest.fixture(
+        params=[
+            (float32, 1),
+            (float64, 1),
+            (float32, 100),
+            (float64, 100),
+        ],
+        scope="function",
+    )
+    def tracker(self, request):
+        return tracker_factory(*request.param)
+
+    def test_new_ground_only_tracker_retains_initial_configuration_as_the_best_one(self, tracker):
         initial_state = np.array([1, -1, 1, 1], dtype=np.int8)
         initial_energy = 5.0
 
-        tracker = tracker_cls(initial_state, initial_energy)
+        tracker.digest(initial_state, initial_energy)
 
         assert_records_agree(tracker, [initial_state], [initial_energy])
 
     def test_modifications_of_initial_state_from_python_code_are_not_reflected_in_tracker(
-        self, tracker_cls
+        self, tracker
     ):
         initial_state = np.array([1, -1, 1, 1], dtype=np.int8)
         initial_energy = 5.0
         expected_state = initial_state.copy()
 
-        tracker = tracker_cls(initial_state, initial_energy)
+        tracker.digest(initial_state, initial_energy)
         initial_state[0] = -1
 
         assert_records_agree(tracker, [expected_state], [initial_energy])
 
     def test_modifications_of_initial_state_from_jit_code_are_not_reflected_in_tracker(
-        self, tracker_cls
+        self, tracker
     ):
         initial_state = np.array([1, -1, 1, 1], dtype=np.int8)
         initial_energy = 5.0
         expected_state = initial_state.copy()
 
-        def _foo(state, energy):
-            tracker = tracker_cls(state, energy)
+        def _foo(state, energy, tracker):
+            tracker.digest(state, energy)
             state[0] = -1
             return tracker.records()
 
-        recorded_states, recorded_energies = _foo(initial_state, initial_energy)
+        recorded_states, recorded_energies = _foo(initial_state, initial_energy, tracker)
         np.testing.assert_array_equal([expected_state], recorded_states)
         assert recorded_energies == [initial_energy]
 
 
-@pytest.mark.parametrize("tracker_cls", [tracker_factory(float32, 1), tracker_factory(float64, 1)])
 class TestGroundOnlyTracker:
     @pytest.fixture(scope="function")
     def input_example(self):
@@ -72,45 +72,45 @@ class TestGroundOnlyTracker:
         best_state, best_energy = states[best_idx], energies[best_idx]
         return states, energies, best_state, best_energy, best_idx
 
-    def test_digesting_new_configuration_with_lower_energy_updates_records(self, tracker_cls):
+    @pytest.fixture(params=[(float32, 1), (float64, 1)], scope="function")
+    def tracker(self, request):
+        return tracker_factory(*request.param)
+
+    def test_digesting_new_configuration_with_lower_energy_updates_records(self, tracker):
         initial_state = np.array([1, -1, -1, 1, 1], dtype=np.int8)
         initial_energy = 2.1
         new_state = np.array([1, 1, -1, 1, -1], dtype=np.int8)
         new_energy = -0.5
-        tracker = tracker_cls(initial_state, initial_energy)
 
+        tracker.digest(initial_state, initial_energy)
         tracker.digest(new_state, new_energy)
 
         assert_records_agree(tracker, [new_state], [new_energy])
 
-    def test_digesting_new_configuration_with_higher_energy_leaves_records_untouched(
-        self, tracker_cls
-    ):
+    def test_digesting_new_configuration_with_higher_energy_leaves_records_untouched(self, tracker):
         initial_state = np.array([1, -1, -1, 1, 1], dtype=np.int8)
         initial_energy = 2.5
         new_state = np.array([1, 1, -1, 1, -1], dtype=np.int8)
         new_energy = 3.0
-        tracker = tracker_cls(initial_state, initial_energy)
-
+        tracker.digest(initial_state, initial_energy)
         tracker.digest(new_state, new_energy)
 
         assert_records_agree(tracker, [initial_state], [initial_energy])
 
     def test_only_single_lowest_energy_state_is_recorded_after_successive_digestions(
-        self, tracker_cls, input_example
+        self, tracker, input_example
     ):
         states, energies, best_state, best_energy, _ = input_example
-        tracker = tracker_cls(states[0], energies[0])
 
-        for state, energy in zip(states[1:], energies[1:]):
+        for state, energy in zip(states, energies):
             tracker.digest(state, energy)
 
         assert_records_agree(tracker, [best_state], [best_energy])
 
-    def test_stored_states_are_copied_in_python_code(self, tracker_cls, input_example):
+    def test_stored_states_are_copied_in_python_code(self, tracker, input_example):
         states, energies, best_state, best_energy, _ = input_example
         expected_state = best_state.copy()
-        tracker = tracker_cls(states[0], energies[0])
+        tracker.digest(states[0], energies[0])
 
         for state, energy in zip(states[1:], energies[1:]):
             tracker.digest(state, energy)
@@ -119,14 +119,13 @@ class TestGroundOnlyTracker:
 
         assert_records_agree(tracker, [expected_state], [best_energy])
 
-    def test_stored_states_are_copied_in_jit_code(self, tracker_cls, input_example):
+    def test_stored_states_are_copied_in_jit_code(self, tracker, input_example):
         states, energies, best_state, best_energy, best_idx = input_example
         expected_state = best_state.copy()
-        tracker = tracker_cls(states[0], energies[0])
 
         @njit
         def _foo(tracker, states, energies):
-            for state, energy in zip(states[1:], energies[1:]):
+            for state, energy in zip(states, energies):
                 tracker.digest(state, energy)
 
             states[best_idx][0] = -states[best_idx][0]
@@ -136,23 +135,29 @@ class TestGroundOnlyTracker:
         assert_records_agree(tracker, [expected_state], [best_energy])
 
 
-@pytest.mark.parametrize(
-    "tracker_factory", [tracker_factory(float32, 5), tracker_factory(float64, 5)]
-)
+@pytest.mark.parametrize("tracker", [(float32, 5), (float64, 5)], indirect=True)
 class TestLowEnergySpectrumTracker:
-    def test_digesting_the_same_record_is_idempotent(self, tracker_factory):
+    @pytest.fixture(
+        params=[
+            (float32, 100),
+            (float64, 100),
+        ]
+    )
+    def tracker(self, request):
+        return tracker_factory(*request.param)
+
+    def test_digesting_the_same_record_is_idempotent(self, tracker):
         initial_state = np.array([-1, 1, 1], dtype=np.int8)
         initial_energy = 0.5
-        tracker = tracker_factory(initial_state, initial_energy)
+        tracker.digest(initial_state, initial_energy)
 
         tracker.digest(initial_state, initial_energy)
 
         assert_records_agree(tracker, [initial_state], [initial_energy])
 
-    def test_records_returns_best_sorted_states(self, tracker_factory):
-        initial_state = np.array([1, 1, 1], dtype=np.int8)
-        initial_energy = -2.5
+    def test_records_returns_best_sorted_states(self, tracker):
         states = [
+            np.array([1, 1, 1], dtype=np.int8),
             np.array([-1, 1, 1], dtype=np.int8),
             np.array([-1, -1, 1], dtype=np.int8),
             np.array([1, -1, 1], dtype=np.int8),
@@ -160,32 +165,31 @@ class TestLowEnergySpectrumTracker:
             np.array([-1, -1, -1], dtype=np.int8),
             np.array([-1, 1, -1], dtype=np.int8),
         ]
-        energies = [-2.0, 2.0, 1.5, -1.0, -0.5, 0.0, 3.0]
-        tracker = tracker_factory(initial_state, initial_energy)
+        energies = [-2.5, -2.0, 2.0, 1.5, -1.0, -0.5, 0.0, 3.0]
 
         for state, energy in zip(states, energies):
             tracker.digest(state, energy)
 
         assert_records_agree(
             tracker,
-            [initial_state, states[0], states[3], states[4], states[5]],
+            [states[0], states[1], states[4], states[5], states[6]],
             [-2.5, -2.0, -1.0, -0.5, 0.0],
         )
 
-    def test_stored_states_are_copied_in_python_code(self, tracker_factory):
+    def test_stored_states_are_copied_in_python_code(self, tracker):
         initial_state = np.array([1, 1, 1], dtype=np.int8)
         initial_energy = -2.5
         new_state = np.array([1, 1, -1], dtype=np.int8)
         expected_state = new_state.copy()
         new_energy = -3.0
-        tracker = tracker_factory(initial_state, initial_energy)
+        tracker.digest(initial_state, initial_energy)
 
         tracker.digest(new_state, new_energy)
         new_state[0] = -1
 
         assert_records_agree(tracker, [expected_state, initial_state], [new_energy, initial_energy])
 
-    def test_stored_states_are_copied_in_jit_code(self, tracker_factory):
+    def test_stored_states_are_copied_in_jit_code(self, tracker):
         initial_state = np.array([1, 1, 1], dtype=np.int8)
         initial_energy = -2.5
         new_state = np.array([1, 1, -1], dtype=np.int8)
@@ -197,7 +201,7 @@ class TestLowEnergySpectrumTracker:
             tracker.digest(state, energy)
             state[0] = -state[0]
 
-        tracker = tracker_factory(initial_state, initial_energy)
+        tracker.digest(initial_state, initial_energy)
         _foo(tracker, new_state, new_energy)
 
         assert_records_agree(tracker, [expected_state, initial_state], [new_energy, initial_energy])

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -3,7 +3,7 @@ import pytest
 from numba import njit
 from numba.types import float32, float64
 
-from omnisolver.pt.tracking import tracker_factory
+from omnisolver.pt.tracking import construct_tracker
 
 
 def assert_records_agree(tracker, states, energies):
@@ -23,7 +23,7 @@ class TestTrackersInitialization:
         scope="function",
     )
     def tracker(self, request):
-        return tracker_factory(*request.param)
+        return construct_tracker(*request.param)
 
     def test_new_ground_only_tracker_retains_initial_configuration_as_the_best_one(self, tracker):
         initial_state = np.array([1, -1, 1, 1], dtype=np.int8)
@@ -74,7 +74,7 @@ class TestGroundOnlyTracker:
 
     @pytest.fixture(params=[(float32, 1), (float64, 1)], scope="function")
     def tracker(self, request):
-        return tracker_factory(*request.param)
+        return construct_tracker(*request.param)
 
     def test_digesting_new_configuration_with_lower_energy_updates_records(self, tracker):
         initial_state = np.array([1, -1, -1, 1, 1], dtype=np.int8)
@@ -144,7 +144,7 @@ class TestLowEnergySpectrumTracker:
         ]
     )
     def tracker(self, request):
-        return tracker_factory(*request.param)
+        return construct_tracker(*request.param)
 
     def test_digesting_the_same_record_is_idempotent(self, tracker):
         initial_state = np.array([-1, 1, 1], dtype=np.int8)

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -53,3 +53,18 @@ class TestGroundOnlyTracker:
         recorded_states, recorded_energies = tracker.records()
         np.testing.assert_array_equal([initial_state], recorded_states)
         assert recorded_energies == [initial_energy]
+
+    def test_only_single_lowest_energy_state_is_recorded_after_successive_stores(self, tracker_cls):
+        rng = np.random.default_rng(42)
+        energies = rng.integers(0, 10, size=(10)) / 2
+        states = rng.integers(-1, 1, size=(10, 8), dtype=np.int8)
+        idx = np.argmin(energies)
+        best_state, best_energy = states[idx], energies[idx]
+        tracker = tracker_cls(states[0], energies[0])
+
+        for state, energy in zip(states[1:], energies[1:]):
+            tracker.store(state, energy)
+
+        recorded_states, recorded_energies = tracker.records()
+        np.testing.assert_array_equal([best_state], recorded_states)
+        assert recorded_energies == [best_energy]

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -38,3 +38,18 @@ class TestGroundOnlyTracker:
         recorded_states, recorded_energies = tracker.records()
         np.testing.assert_array_equal([new_state], recorded_states)
         assert recorded_energies == [new_energy]
+
+    def test_storing_new_configuration_with_higher_energy_leaves_records_untouched(
+        self, tracker_cls
+    ):
+        initial_state = np.array([1, -1, -1, 1, 1], dtype=np.int8)
+        initial_energy = 2.5
+        new_state = np.array([1, 1, -1, 1, -1], dtype=np.int8)
+        new_energy = 3.0
+        tracker = tracker_cls(initial_state, initial_energy)
+
+        tracker.store(new_state, new_energy)
+
+        recorded_states, recorded_energies = tracker.records()
+        np.testing.assert_array_equal([initial_state], recorded_states)
+        assert recorded_energies == [initial_energy]

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -12,7 +12,15 @@ def assert_records_agree(tracker, states, energies):
     np.testing.assert_array_equal(recorded_energies, energies)
 
 
-@pytest.mark.parametrize("tracker_cls", [tracker_factory(float32, 1), tracker_factory(float64, 1)])
+@pytest.mark.parametrize(
+    "tracker_cls",
+    [
+        tracker_factory(float32, 1),
+        tracker_factory(float64, 1),
+        tracker_factory(float32, 100),
+        tracker_factory(float64, 100),
+    ],
+)
 class TestTrackersInitialization:
     def test_new_ground_only_tracker_retains_initial_configuration_as_the_best_one(
         self, tracker_cls

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -1,14 +1,19 @@
 import numpy as np
 import pytest
+from numba import njit
 from numba.types import float32, float64
 
-from omnisolver.pt.tracking import construct_tracker
+from omnisolver.pt.tracking import tracker_factory
 
 
+def assert_records_agree(tracker, states, energies):
+    recorded_states, recorded_energies = tracker.records()
+    np.testing.assert_array_equal(states, recorded_states)
+    np.testing.assert_array_equal(recorded_energies, energies)
+
+
+@pytest.mark.parametrize("tracker_cls", [tracker_factory(float32, 1), tracker_factory(float64, 1)])
 class TestTrackersInitialization:
-    @pytest.mark.parametrize(
-        "tracker_cls", [construct_tracker(float32, 1), construct_tracker(float64, 1)]
-    )
     def test_new_ground_only_tracker_retains_initial_configuration_as_the_best_one(
         self, tracker_cls
     ):
@@ -17,15 +22,48 @@ class TestTrackersInitialization:
 
         tracker = tracker_cls(initial_state, initial_energy)
 
-        recorded_states, recorded_energies = tracker.records()
-        np.testing.assert_array_equal([initial_state], recorded_states)
+        assert_records_agree(tracker, [initial_state], [initial_energy])
+
+    def test_modifications_of_initial_state_from_python_code_are_not_reflected_in_tracker(
+        self, tracker_cls
+    ):
+        initial_state = np.array([1, -1, 1, 1], dtype=np.int8)
+        initial_energy = 5.0
+        expected_state = initial_state.copy()
+
+        tracker = tracker_cls(initial_state, initial_energy)
+        initial_state[0] = -1
+
+        assert_records_agree(tracker, [expected_state], [initial_energy])
+
+    def test_modifications_of_initial_state_from_jit_code_are_not_reflected_in_tracker(
+        self, tracker_cls
+    ):
+        initial_state = np.array([1, -1, 1, 1], dtype=np.int8)
+        initial_energy = 5.0
+        expected_state = initial_state.copy()
+
+        def _foo(state, energy):
+            tracker = tracker_cls(state, energy)
+            state[0] = -1
+            return tracker.records()
+
+        recorded_states, recorded_energies = _foo(initial_state, initial_energy)
+        np.testing.assert_array_equal([expected_state], recorded_states)
         assert recorded_energies == [initial_energy]
 
 
-@pytest.mark.parametrize(
-    "tracker_cls", [construct_tracker(float32, 1), construct_tracker(float64, 1)]
-)
+@pytest.mark.parametrize("tracker_cls", [tracker_factory(float32, 1), tracker_factory(float64, 1)])
 class TestGroundOnlyTracker:
+    @pytest.fixture(scope="function")
+    def input_example(self):
+        rng = np.random.default_rng(42)
+        energies = rng.integers(0, 10, size=(10)) / 2
+        states = rng.integers(0, 1, size=(10, 8), dtype=np.int8) * 2 - 1
+        best_idx = np.argmin(energies)
+        best_state, best_energy = states[best_idx], energies[best_idx]
+        return states, energies, best_state, best_energy, best_idx
+
     def test_storing_new_configuration_with_lower_energy_updates_records(self, tracker_cls):
         initial_state = np.array([1, -1, -1, 1, 1], dtype=np.int8)
         initial_energy = 2.1
@@ -35,9 +73,7 @@ class TestGroundOnlyTracker:
 
         tracker.store(new_state, new_energy)
 
-        recorded_states, recorded_energies = tracker.records()
-        np.testing.assert_array_equal([new_state], recorded_states)
-        assert recorded_energies == [new_energy]
+        assert_records_agree(tracker, [new_state], [new_energy])
 
     def test_storing_new_configuration_with_higher_energy_leaves_records_untouched(
         self, tracker_cls
@@ -50,21 +86,43 @@ class TestGroundOnlyTracker:
 
         tracker.store(new_state, new_energy)
 
-        recorded_states, recorded_energies = tracker.records()
-        np.testing.assert_array_equal([initial_state], recorded_states)
-        assert recorded_energies == [initial_energy]
+        assert_records_agree(tracker, [initial_state], [initial_energy])
 
-    def test_only_single_lowest_energy_state_is_recorded_after_successive_stores(self, tracker_cls):
-        rng = np.random.default_rng(42)
-        energies = rng.integers(0, 10, size=(10)) / 2
-        states = rng.integers(-1, 1, size=(10, 8), dtype=np.int8)
-        idx = np.argmin(energies)
-        best_state, best_energy = states[idx], energies[idx]
+    def test_only_single_lowest_energy_state_is_recorded_after_successive_stores(
+        self, tracker_cls, input_example
+    ):
+        states, energies, best_state, best_energy, _ = input_example
         tracker = tracker_cls(states[0], energies[0])
 
         for state, energy in zip(states[1:], energies[1:]):
             tracker.store(state, energy)
 
-        recorded_states, recorded_energies = tracker.records()
-        np.testing.assert_array_equal([best_state], recorded_states)
-        assert recorded_energies == [best_energy]
+        assert_records_agree(tracker, [best_state], [best_energy])
+
+    def test_stored_states_are_copied_in_python_code(self, tracker_cls, input_example):
+        states, energies, best_state, best_energy, _ = input_example
+        expected_state = best_state.copy()
+        tracker = tracker_cls(states[0], energies[0])
+
+        for state, energy in zip(states[1:], energies[1:]):
+            tracker.store(state, energy)
+
+        best_state[0] = -best_state[0]
+
+        assert_records_agree(tracker, [expected_state], [best_energy])
+
+    def test_stored_states_are_copied_in_jit_code(self, tracker_cls, input_example):
+        states, energies, best_state, best_energy, best_idx = input_example
+        expected_state = best_state.copy()
+        tracker = tracker_cls(states[0], energies[0])
+
+        @njit
+        def _foo(tracker, states, energies):
+            for state, energy in zip(states[1:], energies[1:]):
+                tracker.store(state, energy)
+
+            states[best_idx][0] = -states[best_idx][0]
+
+        _foo(tracker, states, energies)
+
+        assert_records_agree(tracker, [expected_state], [best_energy])

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+from numba.types import float32, float64
+
+from omnisolver.pt.tracking import construct_tracker
+
+
+class TestTrackersInitialization:
+    @pytest.mark.parametrize(
+        "tracker_cls", [construct_tracker(float32, 1), construct_tracker(float64, 1)]
+    )
+    def test_new_ground_only_tracker_retains_initial_configuration_as_the_best_one(
+        self, tracker_cls
+    ):
+        initial_state = np.array([1, -1, 1, 1], dtype=np.int8)
+        initial_energy = 5.0
+
+        tracker = tracker_cls(initial_state, initial_energy)
+
+        recorded_states, recorded_energies = tracker.records()
+        np.testing.assert_array_equal([initial_state], recorded_states)
+        assert recorded_energies == [initial_energy]
+
+
+@pytest.mark.parametrize(
+    "tracker_cls", [construct_tracker(float32, 1), construct_tracker(float64, 1)]
+)
+class TestGroundOnlyTracker:
+    def test_storing_new_configuration_with_lower_energy_updates_records(self, tracker_cls):
+        initial_state = np.array([1, -1, -1, 1, 1], dtype=np.int8)
+        initial_energy = 2.1
+        new_state = np.array([1, 1, -1, 1, -1], dtype=np.int8)
+        new_energy = -0.5
+        tracker = tracker_cls(initial_state, initial_energy)
+
+        tracker.store(new_state, new_energy)
+
+        recorded_states, recorded_energies = tracker.records()
+        np.testing.assert_array_equal([new_state], recorded_states)
+        assert recorded_energies == [new_energy]


### PR DESCRIPTION
This PR introduces tracking of more than one low-energy state. 

**TL;DR changelog:**
- `PTSampler.sample` now supports `num_states` argument determining how many lowest states should be returned. By default, this is set to 1 to preserve the backwards compatibility.
- The command line interface supports the corresponding `--num_states` argument (set to 1 by default as well)
The returned states are all unique and hence represent low-energy spectrum approximation. In particular, they don't represent the underlying distribution of any of the replicas.

**Technical details:**

The changes are achieved by:
- Composing `Replica` with new tracker objects.
- Implementing two possible trackers, one that tracks a single state and the second one that tracks multiple low-energy states.
- Dispatching creation of tracker object based on `num_states`.
- Adding `num_states` argument to `PTSampler.sample` method and the CLI interface.

Be advised that settings `num_states > 1` may significantly increase the running time of the algorithm, as instead of maintaining a single state and energy, each replica will keep a heap with additional uniqueness constraints.

**TODO:**
 - [ ] Updating docstrings.
 - [ ] Refactoring code by extracting several repeating code pieces into separate functions.
 - [ ] Adding some more tests using replicas tracking more than one state (although some tests for those cases already do exist)
 - [ ] Measuring the performance impact of `num_states > 1` for the purpose of communicating it in the docs.